### PR TITLE
Fix bearish FVG boundary assignment

### DIFF
--- a/src/smc_detector.py
+++ b/src/smc_detector.py
@@ -107,8 +107,8 @@ def detect_fvg(df: pd.DataFrame) -> List[FVG]:
             fvgs.append(FVG(
                 start_idx=i-2,
                 end_idx=i,
-                top=float(df['low'].iloc[i-2]),
-                bottom=float(df['high'].iloc[i]),
+                top=float(df['high'].iloc[i-2]),
+                bottom=float(df['low'].iloc[i]),
                 direction='down'
             ))
             


### PR DESCRIPTION
## Summary
- Correct bearish FVG detection by using the high two candles back as the top and the current low as the bottom

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2345798348327b706c15fb019709b