### PR TITLE
Add Telegram notification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ venv\Scripts\python.exe live_trading.py --symbol ETHUSDT --quiet --desktop-alert
 🚨 **Smart Alerts**
 - Desktop повідомлення для нових сигналів
 - Звукові сповіщення (опціонально)
+- Telegram повідомлення
 - Детальна інформація (Entry, SL, TP, RR)
 
 ### Контролі Live Monitor
@@ -160,6 +161,8 @@ venv\Scripts\python.exe live_trading.py --symbol ETHUSDT --quiet --desktop-alert
 --sound-alerts           # Увімкнути звукові сповіщення
 --log-level LEVEL        # Рівень логування (INFO/DEBUG)
 --quiet                  # Тихий режим (лог тільки у файл)
+--telegram-token TOKEN   # Telegram bot token для сповіщень
+--telegram-chat-id CHAT  # Telegram chat ID для сповіщень
 ```
 
 ## Порівняння режимів
@@ -178,6 +181,5 @@ venv\Scripts\python.exe live_trading.py --symbol ETHUSDT --quiet --desktop-alert
 - Автоматичне розміщення ордерів на біржі
 - Position management та tracking
 - Більш складний risk management
-- Telegram бот інтеграція
 - Web dashboard інтерфейс
 - Backtesting з live даними

--- a/live_trading.py
+++ b/live_trading.py
@@ -74,6 +74,10 @@ Controls (while running):
                        help='Quiet mode - log only to file, not console')
     parser.add_argument('--status-check-interval', type=int, default=45,
                        help='Signal status check interval in seconds (default: 45)')
+    parser.add_argument('--telegram-token', default=None,
+                       help='Telegram bot token for notifications')
+    parser.add_argument('--telegram-chat-id', default=None,
+                       help='Telegram chat ID for notifications')
     
     args = parser.parse_args()
     
@@ -87,7 +91,9 @@ Controls (while running):
         'fractal_right': args.fractal_right,
         'desktop_alerts': args.desktop_alerts,
         'sound_alerts': args.sound_alerts,
-        'status_check_interval': args.status_check_interval
+        'status_check_interval': args.status_check_interval,
+        'telegram_token': args.telegram_token,
+        'telegram_chat_id': args.telegram_chat_id
     }
     
     # Validate symbol
@@ -101,6 +107,8 @@ Controls (while running):
         print(f"⚙️  Fractal params: {args.fractal_left}/{args.fractal_right}")
         print(f"🔔 Alerts: Desktop={args.desktop_alerts}, Sound={args.sound_alerts}")
         print(f"⏰ Status check interval: {args.status_check_interval}s")
+        if args.telegram_token and args.telegram_chat_id:
+            print("📨 Telegram notifications enabled")
         print(f"📝 Log level: {args.log_level}")
         print("=" * 60)
         print("Press [Ctrl+C] or [Q] to quit")

--- a/src/live_monitor.py
+++ b/src/live_monitor.py
@@ -29,6 +29,7 @@ except ImportError:
 from plyer import notification
 
 from .live_smc_engine import LiveSMCEngine
+from .telegram import send_telegram_message
 
 class LiveMonitorTUI:
     """Terminal User Interface for Live SMC Monitor"""
@@ -379,6 +380,17 @@ class LiveMonitorTUI:
         except Exception as e:
             # Notification might fail on some systems
             pass
+
+        token = self.config.get('telegram_token')
+        chat_id = self.config.get('telegram_chat_id')
+        if token and chat_id:
+            message = (
+                f"SMC Signal - {self.symbol}\n"
+                f"{direction_emoji} {signal['direction']} @ ${signal['entry']:.2f}\n"
+                f"SL: ${signal['sl']:.2f} | TP: ${signal['tp']:.2f}\n"
+                f"RR: {signal['rr']:.1f} | Confidence: {signal.get('confidence', 'medium')}"
+            )
+            send_telegram_message(token, chat_id, message)
             
     def _update_stats(self):
         """Update statistics"""

--- a/src/telegram.py
+++ b/src/telegram.py
@@ -1,0 +1,22 @@
+"""Utility for sending Telegram notifications."""
+import requests
+
+
+def send_telegram_message(token: str, chat_id: str, text: str) -> bool:
+    """Send a Telegram message.
+
+    Args:
+        token: Bot token obtained from @BotFather.
+        chat_id: ID of the chat to send the message to.
+        text: Message text.
+
+    Returns:
+        True if the request succeeded, False otherwise.
+    """
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    payload = {"chat_id": chat_id, "text": text}
+    try:
+        resp = requests.post(url, data=payload, timeout=10)
+        return resp.ok
+    except requests.RequestException:
+        return False

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+from src.telegram import send_telegram_message
+
+
+def test_send_telegram_message_success():
+    token = 'TOKEN'
+    chat_id = 'CHAT'
+    text = 'hello'
+    with patch('src.telegram.requests.post') as mock_post:
+        mock_post.return_value.ok = True
+        assert send_telegram_message(token, chat_id, text) is True
+        mock_post.assert_called_once_with(
+            f'https://api.telegram.org/bot{token}/sendMessage',
+            data={'chat_id': chat_id, 'text': text},
+            timeout=10
+        )


### PR DESCRIPTION
## Summary
- add CLI options for Telegram bot token and chat ID
- implement utility to send Telegram messages and integrate with live monitor
- document Telegram alerts and add unit test

## Testing
- `pytest` *(fails: test_detect_fvg_bearish)*

------
https://chatgpt.com/codex/tasks/task_e_68a239e5eb788327960a544206d66b5f